### PR TITLE
Adding support to extract custom tags in ring handler

### DIFF
--- a/src/meajurements/ring.clj
+++ b/src/meajurements/ring.clj
@@ -3,17 +3,20 @@
 
 (defn wrap-statsd-reporting
   "Instruments response times and API status codes. Wrap your handler function with this."
-  [handler app-name api-name]
-  (fn [request]
-    (let [start-time (System/nanoTime)
-          {:keys [status] :as response} (handler request)]
-      (core/timing (str app-name ".api.response-time." api-name)
-                   (quot (- (System/nanoTime) start-time) 1000000)
-                   {:api-name api-name
-                    :status   status
-                    :app-name app-name})
-      (core/increment (str app-name ".api.count." api-name)
-                      {:api-name api-name
-                       :status   status
-                       :app-name app-name})
-      response)))
+  ([handler app-name api-name]
+   (wrap-statsd-reporting handler app-name api-name (fn [_ _] {})))
+  ([handler app-name api-name tags-fn]
+   (fn [request]
+     (let [start-time (System/nanoTime)
+           {:keys [status] :as response} (handler request)
+           elapsed-time (quot (- (System/nanoTime) start-time) 1000000)
+           tags (merge {:api-name api-name
+                        :status   status
+                        :app-name app-name}
+                       (tags-fn request response))]
+       (core/timing (str app-name ".api.response-time." api-name)
+                    elapsed-time
+                    tags)
+       (core/increment (str app-name ".api.count." api-name)
+                       tags)
+       response))))

--- a/test/meajurements/ring_test.clj
+++ b/test/meajurements/ring_test.clj
@@ -37,3 +37,35 @@
                  :status   200
                  :app-name "foo-app-name"}]
                @increment-args))))))
+
+(deftest statsd-reporting-custom-tags-test
+  (testing "when the handler is instrumented with named-handler"
+    (testing "timing is called with the correct arguments"
+      (let [timing-args (atom nil)
+            wrapped-handler (-> (constantly {:status 200 :body "ok"})
+                                (ring/wrap-statsd-reporting "foo-app-name" "foo-api-name" (fn [req _]
+                                                                                            (select-keys req [:country-id]))))]
+        (with-redefs [core/timing (fn [& args]
+                                    (reset! timing-args (vec args)))]
+          (wrapped-handler {:country-id "SG"}))
+        (is (= ["foo-app-name.api.response-time.foo-api-name"
+                {:api-name "foo-api-name"
+                 :status   200
+                 :app-name "foo-app-name"
+                 :country-id "SG"}]
+               (remove-index @timing-args 1)))))
+
+    (testing "increment is called with the correct arguments"
+      (let [increment-args (atom nil)
+            wrapped-handler (-> (constantly {:status 200 :body "ok"})
+                                (ring/wrap-statsd-reporting "foo-app-name" "foo-api-name" (fn [req _]
+                                                                                            (select-keys req [:country-id]))))]
+        (with-redefs [core/increment (fn [& args]
+                                       (reset! increment-args (vec args)))]
+          (wrapped-handler {:country-id "SG"}))
+        (is (= ["foo-app-name.api.count.foo-api-name"
+                {:api-name "foo-api-name"
+                 :status   200
+                 :app-name "foo-app-name"
+                 :country-id "SG"}]
+               @increment-args))))))


### PR DESCRIPTION
Fixes #3 

This PR adds an overloaded version of the existing ring handler, It accepts one more user defined function as a parameter which accepts **request** and **response** as a parameter, and returns custom tags to be used while emitting latency and throughput metrics.